### PR TITLE
Selection connection groups when requesting, confirming, or inviting connections

### DIFF
--- a/apps/user/src/dao/connection_group_dao.py
+++ b/apps/user/src/dao/connection_group_dao.py
@@ -25,6 +25,7 @@ class ConnectionGroupDao:
             name=name,
             userId=user_id,
             connections=[],
+            invites=[],
             createDate=now,
             updateDate=now,
         )
@@ -54,6 +55,22 @@ class ConnectionGroupDao:
         })
 
         return res.deleted_count == 1
+
+    def add_invite(self, user_id: str, group_id: str, phone_number: str) -> bool:
+        res = self.collection.update_one(
+            filter={"userId": user_id, "_id": group_id},
+            update={"$push": {"invites": phone_number}}
+        )
+
+        return res.modified_count == 1
+
+    def remove_invite(self, user_id: str, group_id: str, phone_number: str) -> bool:
+        res = self.collection.update_one(
+            filter={"userId": user_id, "_id": group_id},
+            update={"$pull": {"invites": phone_number}}
+        )
+
+        return res.modified_count == 1
 
     def add_user(self, user_id: str, group_id: str, connected_user_id: str) -> bool:
         res = self.collection.update_one(

--- a/apps/user/src/dao/connection_request_dao.py
+++ b/apps/user/src/dao/connection_request_dao.py
@@ -32,7 +32,7 @@ class ConnectionRequestDao:
         }))
 
     def create_connection_request(self, requesting_user: UserView, requested_user_id: str,
-                                  permission_group_name: str) -> ConnectionRequestDocument:
+                                  permission_group_name: str, connection_group_ids: List[str]) -> ConnectionRequestDocument:
         now = datetime.now(timezone.utc).isoformat()
         document = ConnectionRequestDocument(
             requestingUserId=requesting_user.id,
@@ -41,6 +41,7 @@ class ConnectionRequestDao:
             requesterFirstName=requesting_user.firstName,
             requesterLastName=requesting_user.lastName,
             requestingPermissionGroupName=permission_group_name,
+            requestingConnectionGroupIds=connection_group_ids,
             status=RequestStatus.PENDING,
             createDate=now,
             updateDate=now,

--- a/apps/user/src/dao/invite_dao.py
+++ b/apps/user/src/dao/invite_dao.py
@@ -1,13 +1,10 @@
 import os
 import uuid
 from datetime import datetime, timezone
-from textwrap import dedent
 from typing import List
 
-import boto3
 import pymongo
 from pymongo.synchronous.collection import Collection
-from types_boto3_sns import SNSClient
 
 from src.model.document import UserInviteDocument
 
@@ -20,12 +17,14 @@ class InviteDao:
     def get_invites(self, phone_number: str) -> List[UserInviteDocument]:
         return list(self.collection.find(filter={"invitedPhoneNumber": phone_number}))
 
-    def create_invite(self, phone_number: str, requesting_user_id: str, permission_group: str) -> UserInviteDocument:
+    def create_invite(self, phone_number: str, requesting_user_id: str, permission_group: str,
+                      connection_group_ids: List[str]) -> UserInviteDocument:
         document = UserInviteDocument(
             _id=str(uuid.uuid4()),
             invitedPhoneNumber=phone_number,
             requesterUserId=requesting_user_id,
             requesterPermissionGroupName=permission_group,
+            requesterConnectionGroupIds=connection_group_ids,
             createDate=datetime.now(timezone.utc)
         )
 

--- a/apps/user/src/functions/connection_handler.py
+++ b/apps/user/src/functions/connection_handler.py
@@ -27,7 +27,7 @@ def confirm_connection(event, context):
     body = json.loads(event.get('body', '{}'))
 
     request = ConfirmConnectionRequest(requestedUserId=path_params.get("userId"), **body)
-    res = connection_service.confirm_connection(request=request)
+    res = connection_service.confirm_connection(confirm_request=request)
     return create_response(200, res)
 
 

--- a/apps/user/src/model/connection/connection_group.py
+++ b/apps/user/src/model/connection/connection_group.py
@@ -11,6 +11,7 @@ class ConnectionGroupView(View):
     userId: str
     name: str
     connections: List[str]
+    invites: List[str]
 
     @staticmethod
     def from_document(doc: ConnectionGroupDocument):
@@ -18,7 +19,8 @@ class ConnectionGroupView(View):
             id=doc.get("_id"),
             name=doc.get("name"),
             userId=doc.get("userId"),
-            connections=doc.get("connections")
+            connections=doc.get("connections"),
+            invites=doc.get("invites")
         )
 
     def add_user(self, user_id: str):

--- a/apps/user/src/model/connection/connection_request.py
+++ b/apps/user/src/model/connection/connection_request.py
@@ -1,5 +1,6 @@
 import os
 from dataclasses import dataclass
+from typing import List
 
 from src.model.constants import DEFAULT_ALL_PERMISSION_GROUP_NAME
 from src.model.document import ConnectionRequestDocument
@@ -15,6 +16,7 @@ class ConnectionRequestView(View):
     requesterLastName: str
     requesterImage: str
     requestingPermissionGroupName: str
+    requestingConnectionGroupIds: List[str]
     status: RequestStatus
 
     @staticmethod
@@ -26,5 +28,6 @@ class ConnectionRequestView(View):
             requesterLastName=doc.get("requesterLastName"),
             requesterImage=doc.get("requesterImage", os.environ["DEFAULT_PROFILE_IMAGE"]),
             requestingPermissionGroupName=doc.get("requestingPermissionGroupName", DEFAULT_ALL_PERMISSION_GROUP_NAME),
+            requestingConnectionGroupIds=doc.get("requestingConnectionGroupIds", []),
             status=doc.get("status")
         )

--- a/apps/user/src/model/document.py
+++ b/apps/user/src/model/document.py
@@ -82,6 +82,7 @@ class ConnectionGroupDocument(TypedDict):
     userId: str
     name: str
     connections: List[str]
+    invites: List[str]
     createDate: str
     updateDate: str
 
@@ -93,6 +94,7 @@ class ConnectionRequestDocument(TypedDict):
     requesterLastName: str
     requesterImage: str
     requestingPermissionGroupName: str
+    requestingConnectionGroupIds: List[str]
     status: RequestStatus
     createDate: str
     updateDate: str
@@ -113,4 +115,5 @@ class UserInviteDocument(TypedDict):
     invitedPhoneNumber: str
     requesterUserId: str
     requesterPermissionGroupName: str
+    requesterConnectionGroupIds: List[str]
     createDate: datetime

--- a/apps/user/src/model/requests.py
+++ b/apps/user/src/model/requests.py
@@ -99,12 +99,14 @@ class RequestConnectionRequest(BaseModel):
     requesting_user_id: str = Field(alias="requestingUserId")
     requested_user_id: str = Field(alias="otherUserId")
     permission_group_name: str = Field(alias="permissionGroupName")
+    connection_group_ids: List[str] = Field(alias="connectionGroupIds", default=[])
 
 
 class ConfirmConnectionRequest(BaseModel):
     requesting_user_id: str = Field(alias="otherUserId")
     requested_user_id: str = Field(alias="requestedUserId")
     permission_group_name: str = Field(alias="permissionGroupName")
+    connection_group_ids: List[str] = Field(alias="connectionGroupIds", default=[])
 
 
 class AddConnectionToGroupRequest(BaseModel):
@@ -142,3 +144,4 @@ class InviteConnectionRequest(BaseModel):
     requesting_user_id: str = Field(alias="requestingUserId")
     requested_phone_number: str = Field(alias="phoneNumber")
     permission_group_name: str = Field(alias="permissionGroupName")
+    connection_group_ids: List[str] = Field(alias="connectionGroupIds", default=[])

--- a/apps/user/src/service/connection_service.py
+++ b/apps/user/src/service/connection_service.py
@@ -84,13 +84,15 @@ class ConnectionService:
         elif existing_request and existing_request.status == RequestStatus.PENDING:
             request = ConfirmConnectionRequest(otherUserId=requested_user.id,
                                                requestedUserId=requesting_user.id,
-                                               permissionGroupName=request.permission_group_name)
-            return self.confirm_connection(request=request)
+                                               permissionGroupName=request.permission_group_name,
+                                               connectionGroupIds=request.connection_group_ids)
+            return self.confirm_connection(confirm_request=request)
 
         # All checks pass... Create the new request!
         new_request = self.connection_request_dao.create_connection_request(requesting_user=requesting_user,
                                                                             requested_user_id=requested_user.id,
-                                                                            permission_group_name=request.permission_group_name)
+                                                                            permission_group_name=request.permission_group_name,
+                                                                            connection_group_ids=request.connection_group_ids)
 
         # Notify the requested user and remove the requested user as a suggestion
         request_text = f"{requesting_user.firstName} would like to connect!"
@@ -99,52 +101,79 @@ class ConnectionService:
 
         return ConnectionRequestView.from_doc(new_request)
 
-    def confirm_connection(self, request: ConfirmConnectionRequest) -> ConnectionRequestView:
-        existing_request = self.get_connection_request(requesting_user=request.requesting_user_id,
-                                                       requested_user=request.requested_user_id)
-        if not existing_request:
+    def confirm_connection(self, confirm_request: ConfirmConnectionRequest) -> ConnectionRequestView:
+        connection_request = self.get_connection_request(requesting_user=confirm_request.requesting_user_id,
+                                                         requested_user=confirm_request.requested_user_id)
+        if not connection_request:
             raise ConnectionRequestDoesNotExistError()
 
-        requesting_user = self.user_service.get_user(user_id=request.requesting_user_id)
+        requesting_user = self.user_service.get_user(user_id=confirm_request.requesting_user_id)
         if not requesting_user:
-            raise UserNotFoundError(request.requesting_user_id)
+            raise UserNotFoundError(confirm_request.requesting_user_id)
 
-        requested_user = self.user_service.get_user(user_id=request.requested_user_id)
+        requested_user = self.user_service.get_user(user_id=confirm_request.requested_user_id)
         if not requested_user:
-            raise UserNotFoundError(request.requested_user_id)
+            raise UserNotFoundError(confirm_request.requested_user_id)
 
-        if existing_request.status != RequestStatus.PENDING:
+        if connection_request.status != RequestStatus.PENDING:
             raise InvalidRequestError("Request is not in a pending status")
 
         # All checks pass!
         # Update the connection request status
         # Create the connections for both users
+        # Add each user to the requested connection groups (remove from invite list if applicable)
         # Remove each user as suggestions to each other
         # Send a notification
         # TODO - use asyncio to run these operations in parallel
-        existing_request.status = RequestStatus.APPROVED
-        self.connection_request_dao.update_connection_request(requesting_user_id=request.requesting_user_id,
-                                                              requested_user_id=request.requested_user_id,
+        connection_request.status = RequestStatus.APPROVED
+        self.connection_request_dao.update_connection_request(requesting_user_id=confirm_request.requesting_user_id,
+                                                              requested_user_id=confirm_request.requested_user_id,
                                                               status=RequestStatus.APPROVED)
 
-        self.connection_dao.create_connection(user_id=request.requesting_user_id,
-                                              connected_user_id=request.requested_user_id,
-                                              permission_group_name=existing_request.requestingPermissionGroupName)
+        self.connection_dao.create_connection(user_id=confirm_request.requesting_user_id,
+                                              connected_user_id=confirm_request.requested_user_id,
+                                              permission_group_name=connection_request.requestingPermissionGroupName)
 
-        self.connection_dao.create_connection(user_id=request.requested_user_id,
-                                              connected_user_id=request.requesting_user_id,
-                                              permission_group_name=request.permission_group_name)
+        self.connection_dao.create_connection(user_id=confirm_request.requested_user_id,
+                                              connected_user_id=confirm_request.requesting_user_id,
+                                              permission_group_name=confirm_request.permission_group_name)
+
+        # The user that created the request wants to add them to some groups once they are connected
+        if len(connection_request.requestingConnectionGroupIds):
+            existing_groups = self.get_connection_groups(user_id=confirm_request.requesting_user_id)
+            for group in [g for g in existing_groups if g.id in connection_request.requestingConnectionGroupIds]:
+                print(f"Adding {confirm_request.requested_user_id} to group {group.name}")
+                self.connection_group_dao.add_user(user_id=confirm_request.requesting_user_id,
+                                                   group_id=group.id,
+                                                   connected_user_id=confirm_request.requested_user_id)
+                if requested_user.phoneNumber in group.invites:
+                    self.connection_group_dao.remove_invite(user_id=confirm_request.requesting_user_id,
+                                                            group_id=group.id,
+                                                            phone_number=requested_user.phoneNumber)
+
+        # The user that confirmed the request wants to add them to some groups once they are connected
+        if len(confirm_request.connection_group_ids):
+            existing_groups = self.get_connection_groups(user_id=confirm_request.requested_user_id)
+            for group in [g for g in existing_groups if g.id in confirm_request.connection_group_ids]:
+                print(f"Adding {confirm_request.requesting_user_id} to group {group.name}")
+                self.connection_group_dao.add_user(user_id=confirm_request.requested_user_id,
+                                                   group_id=group.id,
+                                                   connected_user_id=confirm_request.requesting_user_id)
+                if requesting_user.phoneNumber in group.invites:
+                    self.connection_group_dao.remove_invite(user_id=confirm_request.requested_user_id,
+                                                            group_id=group.id,
+                                                            phone_number=requesting_user.phoneNumber)
 
         request_text = f"{requested_user.firstName} accepted your request!"
-        self.notification_service.send_notification(user_id=request.requesting_user_id, message=request_text)
+        self.notification_service.send_notification(user_id=confirm_request.requesting_user_id, message=request_text)
 
-        self.suggestion_service.remove_suggestion(user_id=request.requesting_user_id,
-                                                  suggested_user_id=request.requested_user_id)
+        self.suggestion_service.remove_suggestion(user_id=confirm_request.requesting_user_id,
+                                                  suggested_user_id=confirm_request.requested_user_id)
 
-        self.suggestion_service.remove_suggestion(user_id=request.requested_user_id,
-                                                  suggested_user_id=request.requesting_user_id)
+        self.suggestion_service.remove_suggestion(user_id=confirm_request.requested_user_id,
+                                                  suggested_user_id=confirm_request.requesting_user_id)
 
-        return existing_request
+        return connection_request
 
     def deny_connection(self, request: DenyConnectionRequest) -> ConnectionRequestView:
         existing_request = self.get_connection_request(requesting_user=request.other_user_id,
@@ -250,6 +279,10 @@ class ConnectionService:
 
         new_group = self.connection_group_dao.create_group(user_id=request.user_id, name=request.name)
         return ConnectionGroupView.from_document(new_group)
+
+    def get_connection_group(self, user_id: str, group_id: str) -> ConnectionGroupView:
+        doc = self.connection_group_dao.get_group(user_id=user_id, group_id=group_id)
+        return ConnectionGroupView.from_document(doc)
 
     def get_connection_groups(self, user_id: str) -> List[ConnectionGroupView]:
         docs = self.connection_group_dao.get_groups(user_id=user_id)

--- a/apps/user/src/service/invite_service.py
+++ b/apps/user/src/service/invite_service.py
@@ -1,5 +1,6 @@
 import logging
 
+from src.dao.connection_group_dao import ConnectionGroupDao
 from src.dao.invite_dao import InviteDao
 from src.model.errors import UserNotFoundError
 from src.model.requests import InviteConnectionRequest, SearchRequest
@@ -13,6 +14,7 @@ class InviteService:
     def __init__(self):
         self.user_service = UserService()
         self.invite_dao = InviteDao()
+        self.connection_group_dao = ConnectionGroupDao()
 
     async def invite_user(self, request: InviteConnectionRequest):
         user = self.user_service.get_user(user_id=request.requesting_user_id)
@@ -37,4 +39,11 @@ class InviteService:
         logger.info(f"Creating invite from {user.id} to user {formatted_number}")
         self.invite_dao.create_invite(phone_number=formatted_number,
                                       requesting_user_id=user.id,
-                                      permission_group=request.permission_group_name)
+                                      permission_group=request.permission_group_name,
+                                      connection_group_ids=request.connection_group_ids)
+
+        existing_groups = self.connection_group_dao.get_groups(user_id=user.id)
+        for group in [g for g in existing_groups if g.get("_id") in request.connection_group_ids]:
+            group_id = group.get('_id')
+            logger.info(f"Adding invited number {formatted_number} to group {group_id}")
+            self.connection_group_dao.add_invite(user_id=user.id, group_id=group_id, phone_number=formatted_number)

--- a/apps/user/src/service/user_service.py
+++ b/apps/user/src/service/user_service.py
@@ -46,9 +46,11 @@ class UserService:
                 continue
 
             permission_group = invite.get("requesterPermissionGroupName")
+            connection_group_ids = invite.get("requesterConnectionGroupIds", [])
             self.connection_request_dao.create_connection_request(requesting_user=requesting_user,
                                                                   requested_user_id=user.get("_id"),
-                                                                  permission_group_name=permission_group)
+                                                                  permission_group_name=permission_group,
+                                                                  connection_group_ids=connection_group_ids)
         return UserView.from_doc(user)
 
     async def search_potential_contacts(self, user_id: str, phone_numbers: List[str]) -> ContactSearchResponse:

--- a/apps/user/tests/integration/integration_test.py
+++ b/apps/user/tests/integration/integration_test.py
@@ -322,10 +322,11 @@ class IntegrationTest:
                                                               group_id=group_id,
                                                               connected_user_id=connected_user_id)
 
-    def create_invite(self, user_id: str, phone_number: str) -> UserInviteDocument:
+    def create_invite(self, user_id: str, phone_number: str, connection_group_ids: List[str]) -> UserInviteDocument:
         return self.invite_service.invite_dao.create_invite(phone_number=format_phone_number(phone_number),
                                                             requesting_user_id=user_id,
-                                                            permission_group="All Info")
+                                                            permission_group="All Info",
+                                                            connection_group_ids=connection_group_ids)
 
     def get_invites(self, phone_number: str) -> List[UserInviteDocument]:
         return self.invite_service.invite_dao.get_invites(phone_number=phone_number)

--- a/apps/user/tests/integration/integration_test.py
+++ b/apps/user/tests/integration/integration_test.py
@@ -303,10 +303,14 @@ class IntegrationTest:
         return ConnectionView.from_doc(self.connection_service.connection_dao.get_connection(user_id=user_id,
                                                                                              connected_user_id=connected_user_id))
 
-    def create_connection_request(self, user: UserView, connected_user_id: str) -> ConnectionRequestView:
+    def create_connection_request(self, user: UserView, connected_user_id: str, connection_group_ids=None) -> ConnectionRequestView:
+        if connection_group_ids is None:
+            connection_group_ids = []
+
         doc = self.connection_service.connection_request_dao.create_connection_request(requesting_user=user,
                                                                                        requested_user_id=connected_user_id,
-                                                                                       permission_group_name=DEFAULT_ALL_PERMISSION_GROUP_NAME)
+                                                                                       permission_group_name=DEFAULT_ALL_PERMISSION_GROUP_NAME,
+                                                                                       connection_group_ids=connection_group_ids)
         return ConnectionRequestView.from_doc(doc)
 
     def create_connection_group(self, user_id: str, name: str = generate_random_string(8)) -> ConnectionGroupView:

--- a/apps/user/tests/integration/test_connection.py
+++ b/apps/user/tests/integration/test_connection.py
@@ -1,12 +1,13 @@
 import asyncio
+import uuid
 
-from tests.integration.integration_test import IntegrationTest
 from src.model.connection.connection_group import ConnectionGroupView
 from src.model.constants import DEFAULT_ALL_PERMISSION_GROUP_NAME, DEFAULT_CONTACT_INFO_PERMISSION_GROUP_NAME
 from src.model.enums import RequestStatus
 from src.model.requests import RequestConnectionRequest, ConfirmConnectionRequest, SearchConnectionsRequest, \
     DenyConnectionRequest, UpdateConnectionRequest, BlockConnectionRequest, CreateGroupRequest, \
     AddConnectionToGroupRequest, RemoveConnectionFromGroupRequest
+from tests.integration.integration_test import IntegrationTest
 
 
 class TestConnectionIntegration(IntegrationTest):
@@ -40,20 +41,31 @@ class TestConnectionIntegration(IntegrationTest):
 
     def test_request_connection_creates_connection(self):
         test_user = self.create_user()
-        self.create_connection_request(user=test_user, connected_user_id=self.user.id)
+
+        # Automatically add the user to the test group once the connection gets created
+        test_group = self.create_connection_group(user_id=test_user.id, name="Test")
+        self.create_connection_request(user=test_user,
+                                       connected_user_id=self.user.id,
+                                       connection_group_ids=[test_group.id])
 
         assert self.connection_service.get_connections(SearchConnectionsRequest(userId=self.user.id)).count == 0
         assert self.connection_service.get_connections(SearchConnectionsRequest(userId=test_user.id)).count == 0
 
+        # Automatically add the user to my group once the connection gets created
+        my_group = self.create_connection_group(user_id=self.user.id, name="Test")
         request = RequestConnectionRequest(requestingUserId=self.user.id,
                                            otherUserId=test_user.id,
-                                           permissionGroupName=DEFAULT_ALL_PERMISSION_GROUP_NAME)
+                                           permissionGroupName=DEFAULT_ALL_PERMISSION_GROUP_NAME,
+                                           connectionGroupIds=[my_group.id])
 
         res = self.connection_service.request_connection(request=request)
+
+        # Request was approved, connections were created, users added to the applicable groups
         assert res.status == RequestStatus.APPROVED
         assert self.connection_service.get_connections(SearchConnectionsRequest(userId=self.user.id)).count == 1
         assert self.connection_service.get_connections(SearchConnectionsRequest(userId=test_user.id)).count == 1
-
+        assert len(self.connection_service.get_connection_group(user_id=test_user.id, group_id=test_group.id).connections) == 1
+        assert len(self.connection_service.get_connection_group(user_id=self.user.id, group_id=my_group.id).connections) == 1
 
         expected_notification = {
             "userId": test_user.id,
@@ -72,10 +84,56 @@ class TestConnectionIntegration(IntegrationTest):
         request = ConfirmConnectionRequest(otherUserId=self.user.id,
                                            requestedUserId=test_user.id,
                                            permissionGroupName=DEFAULT_ALL_PERMISSION_GROUP_NAME)
-        self.connection_service.confirm_connection(request=request)
+        self.connection_service.confirm_connection(confirm_request=request)
 
         assert self.connection_service.get_connections(SearchConnectionsRequest(userId=self.user.id)).count == 1
         assert self.connection_service.get_connections(SearchConnectionsRequest(userId=test_user.id)).count == 1
+
+        expected_notification = {
+            "userId": self.user.id,
+            "title": "Nevvi",
+            "body": f"{test_user.firstName} accepted your request!"
+        }
+        assert self.assert_sqs_message_sent(expected_body=expected_notification, queue_url=self.notification_queue)
+
+        expected_message = {
+            "userId": self.user.id,
+        }
+        assert self.assert_sqs_message_sent(expected_body=expected_message, queue_url=self.suggestions_queue)
+
+    def test_confirm_invited_connection(self):
+        test_user = self.create_user()
+
+        my_group = self.create_connection_group(user_id=self.user.id, name="Test")
+        self.connection_service.connection_group_dao.add_invite(user_id=self.user.id,
+                                                                group_id=my_group.id,
+                                                                phone_number=test_user.phoneNumber)
+        test_group = self.connection_service.get_connection_group(user_id=self.user.id, group_id=my_group.id)
+        assert len(test_group.connections) == 0
+        assert len(test_group.invites) == 1
+
+        # Add the test user to the group once the request is confirmed, should ignore an old connection group id
+        bogus_connection_group_id = str(uuid.uuid4())
+        self.create_connection_request(user=self.user,
+                                       connected_user_id=test_user.id,
+                                       connection_group_ids=[my_group.id, bogus_connection_group_id])
+
+        assert self.connection_service.get_connections(SearchConnectionsRequest(userId=self.user.id)).count == 0
+        assert self.connection_service.get_connections(SearchConnectionsRequest(userId=test_user.id)).count == 0
+
+        request = ConfirmConnectionRequest(otherUserId=self.user.id,
+                                           requestedUserId=test_user.id,
+                                           permissionGroupName=DEFAULT_ALL_PERMISSION_GROUP_NAME,
+                                           connectionGroupIds=[])
+        self.connection_service.confirm_connection(confirm_request=request)
+
+        assert self.connection_service.get_connections(SearchConnectionsRequest(userId=self.user.id)).count == 1
+        assert self.connection_service.get_connections(SearchConnectionsRequest(userId=test_user.id)).count == 1
+
+        # Confirmed user got removed from the invite list and added to the connection list
+        test_group = self.connection_service.get_connection_group(user_id=self.user.id, group_id=my_group.id)
+        assert len(test_group.connections) == 1
+        assert len(test_group.invites) == 0
 
         expected_notification = {
             "userId": self.user.id,
@@ -116,13 +174,17 @@ class TestConnectionIntegration(IntegrationTest):
         test_user_two = self.create_user()
 
         # We can see all the info for user one, but only contact info for user two
-        self.create_connection(user_id=test_user_one.id, connected_user_id=self.user.id,
+        self.create_connection(user_id=test_user_one.id,
+                               connected_user_id=self.user.id,
                                permission_group=DEFAULT_ALL_PERMISSION_GROUP_NAME)
-        self.create_connection(user_id=self.user.id, connected_user_id=test_user_one.id,
+        self.create_connection(user_id=self.user.id,
+                               connected_user_id=test_user_one.id,
                                permission_group=DEFAULT_ALL_PERMISSION_GROUP_NAME)
-        self.create_connection(user_id=test_user_two.id, connected_user_id=self.user.id,
+        self.create_connection(user_id=test_user_two.id,
+                               connected_user_id=self.user.id,
                                permission_group=DEFAULT_CONTACT_INFO_PERMISSION_GROUP_NAME)
-        self.create_connection(user_id=self.user.id, connected_user_id=test_user_two.id,
+        self.create_connection(user_id=self.user.id,
+                               connected_user_id=test_user_two.id,
                                permission_group=DEFAULT_ALL_PERMISSION_GROUP_NAME)
 
         user_one_connection = self.connection_service.get_user_connection(user_id=self.user.id,
@@ -161,7 +223,8 @@ class TestConnectionIntegration(IntegrationTest):
         assert test_user_connection.mailingAddress is not None
         assert test_user_connection.birthday is not None
 
-        update_request = UpdateConnectionRequest(userId=self.user.id, otherUserId=test_user.id,
+        update_request = UpdateConnectionRequest(userId=self.user.id,
+                                                 otherUserId=test_user.id,
                                                  permissionGroupName=DEFAULT_CONTACT_INFO_PERMISSION_GROUP_NAME)
         self.connection_service.update_connection(request=update_request)
 
@@ -179,9 +242,11 @@ class TestConnectionIntegration(IntegrationTest):
         test_user = self.create_user()
         self.create_connection_request(user=self.user, connected_user_id=test_user.id)
         self.create_connection_request(user=test_user, connected_user_id=self.user.id)
-        self.create_connection(user_id=test_user.id, connected_user_id=self.user.id,
+        self.create_connection(user_id=test_user.id,
+                               connected_user_id=self.user.id,
                                permission_group=DEFAULT_ALL_PERMISSION_GROUP_NAME)
-        self.create_connection(user_id=self.user.id, connected_user_id=test_user.id,
+        self.create_connection(user_id=self.user.id,
+                               connected_user_id=test_user.id,
                                permission_group=DEFAULT_ALL_PERMISSION_GROUP_NAME)
 
         assert len(self.user.blockedUsers) == 0
@@ -222,9 +287,11 @@ class TestConnectionIntegration(IntegrationTest):
         assert len(new_group.connections) == 0
 
         test_user = self.create_user()
-        self.create_connection(user_id=self.user.id, connected_user_id=test_user.id,
+        self.create_connection(user_id=self.user.id,
+                               connected_user_id=test_user.id,
                                permission_group=DEFAULT_ALL_PERMISSION_GROUP_NAME)
-        self.create_connection(user_id=test_user.id, connected_user_id=self.user.id,
+        self.create_connection(user_id=test_user.id,
+                               connected_user_id=self.user.id,
                                permission_group=DEFAULT_ALL_PERMISSION_GROUP_NAME)
 
         request = AddConnectionToGroupRequest(userId=self.user.id, connectedUserId=test_user.id, groupId=new_group.id)
@@ -240,7 +307,9 @@ class TestConnectionIntegration(IntegrationTest):
         assert len(test_group.connections) == 1
         assert test_user.id in test_group.connections
 
-        request = RemoveConnectionFromGroupRequest(userId=self.user.id, connectedUserId=test_user.id, groupId=new_group.id)
+        request = RemoveConnectionFromGroupRequest(userId=self.user.id,
+                                                   connectedUserId=test_user.id,
+                                                   groupId=new_group.id)
         self.connection_service.remove_connection_from_group(request=request)
 
         test_group = get_group()
@@ -248,9 +317,11 @@ class TestConnectionIntegration(IntegrationTest):
 
     def test_export_group(self):
         test_user = self.create_user()
-        self.create_connection(user_id=self.user.id, connected_user_id=test_user.id,
+        self.create_connection(user_id=self.user.id,
+                               connected_user_id=test_user.id,
                                permission_group=DEFAULT_ALL_PERMISSION_GROUP_NAME)
-        self.create_connection(user_id=test_user.id, connected_user_id=self.user.id,
+        self.create_connection(user_id=test_user.id,
+                               connected_user_id=self.user.id,
                                permission_group=DEFAULT_ALL_PERMISSION_GROUP_NAME)
 
         new_group = self.create_connection_group(user_id=self.user.id)

--- a/apps/user/tests/integration/test_invite.py
+++ b/apps/user/tests/integration/test_invite.py
@@ -8,15 +8,22 @@ from tests.integration.integration_test import IntegrationTest
 class TestInviteIntegration(IntegrationTest):
     def test_invite_user_has_not_been_invited_yet(self):
         invite_number = "6511234567"
-        user_invites = self.get_invites(phone_number=format_phone_number(invite_number))
+        formatted_number = format_phone_number(invite_number)
+        user_invites = self.get_invites(phone_number=formatted_number)
         assert len(user_invites) == 0
 
+        my_group = self.create_connection_group(user_id=self.user.id, name="Test")
         request = InviteConnectionRequest(requestingUserId=self.user.id,
                                           phoneNumber=invite_number,
-                                          permissionGroupName="All Info")
+                                          permissionGroupName="All Info",
+                                          connectionGroupIds=[my_group.id])
 
         asyncio.run(self.invite_service.invite_user(request=request))
 
-        user_invites = self.get_invites(phone_number=format_phone_number(invite_number))
+        user_invites = self.get_invites(phone_number=formatted_number)
         assert len(user_invites) == 1
         assert user_invites[0].get("requesterUserId") == self.user.id
+
+        test_group = self.connection_service.get_connection_group(user_id=self.user.id, group_id=my_group.id)
+        assert len(test_group.invites) == 1
+        assert formatted_number in test_group.invites

--- a/apps/user/tests/integration/test_user.py
+++ b/apps/user/tests/integration/test_user.py
@@ -8,9 +8,11 @@ from tests.integration.integration_test import IntegrationTest
 
 class TestUserIntegration(IntegrationTest):
     def test_create_user_initializes_fields(self):
-        phone_number = "6511234567"
         test_user_one = self.create_user(first_name="Jane", last_name="Doe")
-        self.create_invite(user_id=test_user_one.id, phone_number=phone_number)
+
+        phone_number = "6511234567"
+        test_group = self.create_connection_group(user_id=test_user_one.id, name="Test")
+        self.create_invite(user_id=test_user_one.id, phone_number=phone_number, connection_group_ids=[test_group.id])
 
         user_id = str(uuid.uuid4())
         assert len(self.connection_service.get_pending_requests(user_id=user_id)) == 0
@@ -27,6 +29,7 @@ class TestUserIntegration(IntegrationTest):
         assert len(pending_requests) == 1
         assert pending_requests[0].requestingUserId == test_user_one.id
         assert pending_requests[0].requestedUserId == user_id
+        assert pending_requests[0].requestingConnectionGroupIds == [test_group.id]
 
         new_user = self.user_service.get_user(user_id=user_id)
         assert user == new_user


### PR DESCRIPTION
- `invites` on the connection group helps us keep track of users that were invited to join Nevvi **and** add to a connection group once the automated request is confirmed. This helps the owner of the group keep track of who hasn't joined Nevvi yet
- When requesting a connection you can pass a list of connection group ids that will automatically get modified when the request is confirmed by the requested user
- When confirmed a connection you can pass a list of connection group ids that will automatically get modified with the new connection